### PR TITLE
Drops Spawner Refactor

### DIFF
--- a/mapinfo.txt
+++ b/mapinfo.txt
@@ -11,6 +11,7 @@ gameinfo
 	// AddEventHandlers = "MonstersCacheHandler" - UNUSED for now
 	AddEventHandlers = "AmmoDropsHandler"
 	AddEventHandlers = "DropsHandler"
+	AddEventHandlers = "DropDatabase"
 	AddEventHandlers = "ExperienceGivingHandler"
 	AddEventHandlers = "DroppedItemsUnclumpHandler"
 	AddEventHandlers = "MonstersAffixingHandler"

--- a/mapinfo.txt
+++ b/mapinfo.txt
@@ -11,7 +11,7 @@ gameinfo
 	// AddEventHandlers = "MonstersCacheHandler" - UNUSED for now
 	AddEventHandlers = "AmmoDropsHandler"
 	AddEventHandlers = "DropsHandler"
-	AddEventHandlers = "DropDatabase"
+	AddEventHandlers = "DropDatabaseHandler"
 	AddEventHandlers = "ExperienceGivingHandler"
 	AddEventHandlers = "DroppedItemsUnclumpHandler"
 	AddEventHandlers = "MonstersAffixingHandler"

--- a/zscript.zsc
+++ b/zscript.zsc
@@ -56,6 +56,7 @@ version "4.10.0"
 #include "zscript/affixable/stats_scaling.zs"
 
 #include "zscript/drops/ammo_drops_handler.zs"
+#include "zscript/drops/drops_database.zs"
 #include "zscript/drops/drops_decider.zs"
 #include "zscript/drops/drops_handler.zs"
 #include "zscript/drops/drops_handler_progression.zs"

--- a/zscript/drops/drops_database.zs
+++ b/zscript/drops/drops_database.zs
@@ -7,6 +7,10 @@ class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
     Map<String,int> ArmorItems; // As above, for armor.
     Map<String,int> EquipItems; // Non-armor equipment.
 
+    static DropDatabase Get() {
+        return DropDatabase(StaticEventHandler.Find("DropDatabase"));
+    }
+
     override void OnRegister() {
         // Start by pushing all the known OneTimeItems.
         // TODO: Better way of doing this.
@@ -73,7 +77,8 @@ class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
 
     int WeightedRand(Array<int> weights) {
         int sum = 0;
-        foreach (w : weights) {
+        for (int i = 0; i < weights.size(); i++) {
+            int w = weights[i];
             sum += w;
         }
         if (sum <= 0) { debug.panic("Bad weights sent."); }
@@ -96,11 +101,10 @@ class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
         MapIterator<String,int> it;
         Array<int> weights;
         Array<string> results;
-        if (it.init(items)) {
-            while (it.Valid() && it.Next()) {
-                weights.push(it.GetValue());
-                results.push(it.GetKey());
-            }
+        it.init(items);
+        foreach (k, v : it) {
+            weights.push(v);
+            results.push(k);
         }
 
         // Now we have a list of weights, so we can just do WeightedRand.
@@ -110,6 +114,28 @@ class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
             debug.panic(err);
         }
 
-        return results[selected];
+        string result = results[selected];
+
+        return result;
+    }
+
+    String PickWeapon() {
+        return PickFromWeightList(WeaponItems);
+    }
+
+    String PickArmor() {
+        return PickFromWeightList(ArmorItems);
+    }
+
+    String PickEquip() {
+        return PickFromWeightList(EquipItems);
+    }
+
+    String PickAmmo() {
+        return PickFromWeightList(AmmoItems);
+    }
+
+    String PickOneTimeItem() {
+        return PickFromWeightList(OneTimeItems);
     }
 }

--- a/zscript/drops/drops_database.zs
+++ b/zscript/drops/drops_database.zs
@@ -1,4 +1,4 @@
-class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
+class DropDatabaseHandler : StaticEventHandler { // Good thing this isn't SQL, lmao
     // This class has two jobs:
     // 1. At startup, iterate the whole class list looking for categories of items.
     Map<String,int> OneTimeItems; // Consumables such as Bonuses, Stimpacks, Scrolls, Spheres

--- a/zscript/drops/drops_database.zs
+++ b/zscript/drops/drops_database.zs
@@ -7,8 +7,8 @@ class DropDatabaseHandler : StaticEventHandler { // Good thing this isn't SQL, l
     Map<String,int> ArmorItems; // As above, for armor.
     Map<String,int> EquipItems; // Non-armor equipment.
 
-    static DropDatabase Get() {
-        return DropDatabase(StaticEventHandler.Find("DropDatabase"));
+    static DropDatabaseHandler Get() {
+        return DropDatabaseHandler(StaticEventHandler.Find("DropDatabaseHandler"));
     }
 
     override void OnRegister() {
@@ -75,28 +75,6 @@ class DropDatabaseHandler : StaticEventHandler { // Good thing this isn't SQL, l
     // 2. When something asks for a random drop, give it to them.
 
 
-    int WeightedRand(Array<int> weights) {
-        int sum = 0;
-        for (int i = 0; i < weights.size(); i++) {
-            int w = weights[i];
-            sum += w;
-        }
-        if (sum <= 0) { debug.panic("Bad weights sent."); }
-
-        int selected = random(0,sum-1);
-
-        for (int i = 0; i < weights.Size(); i++) {
-            if (weights[i] > 0 && selected < weights[i]) {
-                return i;
-            }
-
-            selected -= weights[i];
-        }
-
-        debug.panic("Weighted random failed to select an item.");
-        return 0;
-    }
-
     String PickFromWeightList(Map<String,int> items) {
         MapIterator<String,int> it;
         Array<int> weights;
@@ -108,7 +86,7 @@ class DropDatabaseHandler : StaticEventHandler { // Good thing this isn't SQL, l
         }
 
         // Now we have a list of weights, so we can just do WeightedRand.
-        int selected = WeightedRand(weights);
+        int selected = rnd.WeightedRandArr(weights);
         if (selected < 0 || selected > results.Size()) {
             String err = String.format("Invalid result %d from WeightedRand",selected);
             debug.panic(err);

--- a/zscript/drops/drops_database.zs
+++ b/zscript/drops/drops_database.zs
@@ -1,17 +1,79 @@
 class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
     // This class has two jobs:
     // 1. At startup, iterate the whole class list looking for categories of items.
-    Map<int,String> OneTimeItems; // Consumables such as Bonuses, Stimpacks, Scrolls, Spheres
-    Map<int,String> AmmoItems; // Ammunition drops.
-    Map<int,String> WeaponItems; // Types of weapons that can be dropped.
-    Map<int,String> ArmorItems; // As above, for armor.
-    Map<int,String> EquipItems; // Non-armor equipment.
+    Map<String,int> OneTimeItems; // Consumables such as Bonuses, Stimpacks, Scrolls, Spheres
+    Map<String,int> AmmoItems; // Ammunition drops.
+    Map<String,int> WeaponItems; // Types of weapons that can be dropped.
+    Map<String,int> ArmorItems; // As above, for armor.
+    Map<String,int> EquipItems; // Non-armor equipment.
+
+    override void OnRegister() {
+        // Start by pushing all the known OneTimeItems.
+        // TODO: Better way of doing this.
+        OneTimeItems.insert("RwArmorBonus",400);
+        OneTimeItems.insert("HealthBonus",400);
+        OneTimeItems.insert("Stimpack",100);
+        OneTimeItems.insert("Blursphere",10);
+        OneTimeItems.insert("Soulsphere",7);
+        OneTimeItems.insert("Berserk",5);
+        OneTimeItems.insert("MegaSphere",3);
+        OneTimeItems.insert("InvulnerabilitySphere",1);
+        OneTimeItems.insert("StatScroll",10);
+        OneTimeItems.insert("RwFlaskRefill",200);
+        // Also, ammo items.
+        // No plans to add new ammo, AFAIK.
+        AmmoItems.insert("Clip",5);
+        AmmoItems.insert("Shell",5);
+        AmmoItems.insert("RocketAmmo",1);
+        AmmoItems.insert("Cell",2);
+
+        // And now, iterate the whole class list...
+        // I might be able to make this even more flexible later.
+        // There's a way to check if a class has a function,
+        // which would mean that I could have each of these implement a "GetRandWeight()" function
+        // and then check for the presence of that function
+        // to insert items into the drop tables.
+        // This would necessarily mean unifying all of the item drops into one table, though.
+        foreach (c : AllClasses) {
+            // Don't include abstract classes.
+            if (c.isAbstract()) {
+                continue;
+            }
+            // Sort items into their proper lists.
+            if (c is "RandomizedWeapon") {
+                Class<Actor> rwc = c.GetClassName();
+                let rw = RandomizedWeapon(GetDefaultByType(rwc));
+                WeaponItems.Insert(rw.GetClassName(),rw.rweight);
+                console.printf("Weapon - %s (%d)",rw.GetClassName(),rw.rweight);
+            }
+            if (c is "RandomizedArmor") {
+                Class<Actor> rac = c.GetClassName();
+                let ra = RandomizedArmor(GetDefaultByType(rac));
+                ArmorItems.Insert(ra.GetClassName(),ra.rweight);
+                console.printf("Armor - %s (%d)",ra.GetClassName(),ra.rweight);
+            }
+            if (c is "RwBackpack") {
+                Class<Actor> bpc = c.GetClassName();
+                let bp = RwBackpack(GetDefaultByType(bpc));
+                EquipItems.Insert(bp.GetClassName(),bp.rweight);
+                console.printf("Backpack - %s (%d)",bp.GetClassName(),bp.rweight);
+            }
+            if (c is "RwFlask") {
+                Class<Actor> flc = c.GetClassName();
+                let fl = RwFlask(GetDefaultByType(flc));
+                EquipItems.Insert(fl.GetClassName(),fl.rweight);
+                console.printf("Flask - %s (%d)",fl.GetClassName(),fl.rweight);
+            }
+        }
+
+    }
 
     // 2. When something asks for a random drop, give it to them.
 
+
     int WeightedRand(Array<int> weights) {
         int sum = 0;
-        for (w : weights) {
+        foreach (w : weights) {
             sum += w;
         }
         if (sum <= 0) { debug.panic("Bad weights sent."); }
@@ -30,14 +92,14 @@ class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
         return 0;
     }
 
-    String PickFromWeightList(Map<int,String> items) {
-        MapIterator<int,String> it;
+    String PickFromWeightList(Map<String,int> items) {
+        MapIterator<String,int> it;
         Array<int> weights;
         Array<string> results;
-        if (it.init(items);) {
+        if (it.init(items)) {
             while (it.Valid() && it.Next()) {
-                weights.push(it.GetKey());
-                results.push(it.GetValue());
+                weights.push(it.GetValue());
+                results.push(it.GetKey());
             }
         }
 

--- a/zscript/drops/drops_database.zs
+++ b/zscript/drops/drops_database.zs
@@ -1,0 +1,53 @@
+class DropDatabase : StaticEventHandler { // Good thing this isn't SQL, lmao
+    // This class has two jobs:
+    // 1. At startup, iterate the whole class list looking for categories of items.
+    Map<int,String> OneTimeItems; // Consumables such as Bonuses, Stimpacks, Scrolls, Spheres
+    Map<int,String> AmmoItems; // Ammunition drops.
+    Map<int,String> WeaponItems; // Types of weapons that can be dropped.
+    Map<int,String> ArmorItems; // As above, for armor.
+    Map<int,String> EquipItems; // Non-armor equipment.
+
+    // 2. When something asks for a random drop, give it to them.
+
+    int WeightedRand(Array<int> weights) {
+        int sum = 0;
+        for (w : weights) {
+            sum += w;
+        }
+        if (sum <= 0) { debug.panic("Bad weights sent."); }
+
+        int selected = random(0,sum-1);
+
+        for (int i = 0; i < weights.Size(); i++) {
+            if (weights[i] > 0 && selected < weights[i]) {
+                return i;
+            }
+
+            selected -= weights[i];
+        }
+
+        debug.panic("Weighted random failed to select an item.");
+        return 0;
+    }
+
+    String PickFromWeightList(Map<int,String> items) {
+        MapIterator<int,String> it;
+        Array<int> weights;
+        Array<string> results;
+        if (it.init(items);) {
+            while (it.Valid() && it.Next()) {
+                weights.push(it.GetKey());
+                results.push(it.GetValue());
+            }
+        }
+
+        // Now we have a list of weights, so we can just do WeightedRand.
+        int selected = WeightedRand(weights);
+        if (selected < 0 || selected > results.Size()) {
+            String err = String.format("Invalid result %d from WeightedRand",selected);
+            debug.panic(err);
+        }
+
+        return results[selected];
+    }
+}

--- a/zscript/drops/drops_spawner.zs
+++ b/zscript/drops/drops_spawner.zs
@@ -9,7 +9,7 @@ class DropsSpawner {
 
     static play Actor SpawnRandomOneTimeItemDrop(Actor dropper) {
         Actor itemDrop;
-        DropDatabase db = DropDatabase.Get();
+        DropDatabaseHandler db = DropDatabaseHandler.Get();
         String spawnedClass = db.PickOneTimeItem();
         itemDrop = createDropByClass(dropper,spawnedClass);
         return itemDrop;
@@ -17,7 +17,7 @@ class DropsSpawner {
 
     static play Actor SpawnRandomAmmoDrop(Actor dropper, int maxAmmoPercentage = 200) {
         Actor ammoDrop;
-        DropDatabase db = DropDatabase.Get();
+        DropDatabaseHandler db = DropDatabaseHandler.Get();
         String spawnedClass = db.PickAmmo();
         ammoDrop = createDropByClass(dropper,spawnedClass);
 
@@ -49,7 +49,7 @@ class DropsSpawner {
 
     private static play Actor SpawnRWeaponDrop(Actor dropper) {
         Actor spawnedItem;
-        DropDatabase db = DropDatabase.Get();
+        DropDatabaseHandler db = DropDatabaseHandler.Get();
         String spawnedClass = db.PickWeapon();
         spawnedItem = createDropByClass(dropper,spawnedClass);
         return spawnedItem;
@@ -57,7 +57,7 @@ class DropsSpawner {
 
     private static play Actor SpawnRArmorDrop(Actor dropper) {
         Actor spawnedItem;
-        DropDatabase db = DropDatabase.Get();
+        DropDatabaseHandler db = DropDatabaseHandler.Get();
         String spawnedClass = db.PickArmor();
         spawnedItem = createDropByClass(dropper,spawnedClass);
         return spawnedItem;
@@ -94,7 +94,7 @@ class DropsSpawner {
 
     private static play Actor SpawnREquipDrop(Actor dropper) {
         Actor spawnedItem;
-        DropDatabase db = DropDatabase.Get();
+        DropDatabaseHandler db = DropDatabaseHandler.Get();
         String spawnedClass = db.PickEquip();
         spawnedItem = createDropByClass(dropper,spawnedClass);
         return spawnedItem;

--- a/zscript/drops/drops_spawner.zs
+++ b/zscript/drops/drops_spawner.zs
@@ -8,53 +8,19 @@ class DropsSpawner {
     }
 
     static play Actor SpawnRandomOneTimeItemDrop(Actor dropper) {
-        int dropType = rnd.weightedRand(400, 400, 100, 10, 7, 5, 3, 1, 10, 200);
-        switch (dropType) {
-            case 0: 
-                return createDropByClass(dropper, 'RwArmorBonus');
-            case 1: 
-                return createDropByClass(dropper, 'HealthBonus');
-            case 2: 
-                return createDropByClass(dropper, 'Stimpack');
-            case 3:
-                return createDropByClass(dropper, 'BlurSphere');
-            case 4:
-                return createDropByClass(dropper, 'SoulSphere');
-            case 5:
-                return createDropByClass(dropper, 'Berserk');
-            case 6:
-                return createDropByClass(dropper, 'MegaSphere');
-            case 7:
-                return createDropByClass(dropper, 'InvulnerabilitySphere');
-            case 8:
-                return createDropByClass(dropper, 'StatScroll');
-            case 9:
-                return createDropByClass(dropper, 'RwFlaskRefill');
-            default:
-                debug.panic("Random one-time item drop spawner crashed");
-        }
-        return null;
+        Actor itemDrop;
+        DropDatabase db = DropDatabase.Get();
+        String spawnedClass = db.PickOneTimeItem();
+        itemDrop = createDropByClass(dropper,spawnedClass);
+        return itemDrop;
     }
 
     static play Actor SpawnRandomAmmoDrop(Actor dropper, int maxAmmoPercentage = 200) {
-        int dropType = rnd.weightedRand(5, 5, 1, 2);
         Actor ammoDrop;
-        switch (dropType) {
-            case 0: 
-                ammoDrop = createDropByClass(dropper, 'Clip');
-                break;
-            case 1: 
-                ammoDrop = createDropByClass(dropper, 'Shell');
-                break;
-            case 2: 
-                ammoDrop = createDropByClass(dropper, 'RocketAmmo');
-                break;
-            case 3:
-                ammoDrop = createDropByClass(dropper, 'Cell');
-                break;
-            default:
-                debug.panic("Ammo random drop spawner crashed");
-        }
+        DropDatabase db = DropDatabase.Get();
+        String spawnedClass = db.PickAmmo();
+        ammoDrop = createDropByClass(dropper,spawnedClass);
+
         // Randomly increase dropped ammo amount
         let invItem = Inventory(ammoDrop);
         if (invItem) {
@@ -64,16 +30,17 @@ class DropsSpawner {
     }
 
     static play Actor SpawnRandomRWArtifactItemDrop(Actor dropper) {
-        int dropType = rnd.weightedRand(6, 4, 1, 1);
+        int dropType = rnd.weightedRand(6, 4, 2);
         switch (dropType) {
             case 0: 
                 return SpawnRWeaponDrop(dropper);
             case 1: 
                 return SpawnRArmorDrop(dropper);
             case 2:
-                return SpawnRBackpackDrop(dropper);
-            case 3:
-                return SpawnRFlaskDrop(dropper);
+                return SpawnREquipDrop(dropper); 
+                // Backpacks and Flasks are currently merged into the same drop pool,
+                // which doesn't matter for now because they have equal weights.
+                // May become an issue if new equip slots are added.
             default:
                 debug.panic("SpawnRandomRWArtifactItemDrop crashed");
         }
@@ -82,96 +49,54 @@ class DropsSpawner {
 
     private static play Actor SpawnRWeaponDrop(Actor dropper) {
         Actor spawnedItem;
-        int dropType = rnd.weightedRand(
-            5,  // Chainsaw
-            25, // Pistol
-            25, // Shotgun
-            15, // SSG (it is supported in Doom 1 too)
-            20, // Chaingun
-            20, // SMG
-            10, // Rocket Launcher
-            10, // Plasma Rifle
-            1,  // BFG
-            1   // BFG-2704
-        );
-        switch (dropType) {
-            case 0: 
-                spawnedItem = createDropByClass(dropper, 'RwChainsaw');
-                break;
-            case 1: 
-                spawnedItem = createDropByClass(dropper, 'RwPistol');
-                break;
-            case 2: 
-                spawnedItem = createDropByClass(dropper, 'RwShotgun');
-                break;
-            case 3: 
-                spawnedItem = createDropByClass(dropper, 'RwSuperShotgun');
-                break;
-            case 4: 
-                spawnedItem = createDropByClass(dropper, 'RwChaingun');
-                break;
-            case 5:
-                spawnedItem = createDropByClass(dropper, 'RwSmg');
-                break;
-            case 6: 
-                spawnedItem = createDropByClass(dropper, 'RwRocketLauncher');
-                break;
-            case 7: 
-                spawnedItem = createDropByClass(dropper, 'RwPlasmarifle');
-                break;
-            case 8:
-                spawnedItem = createDropByClass(dropper, 'RwBFG');
-                break;
-            case 9:
-                spawnedItem = createDropByClass(dropper, 'RwBFG2704');
-                break;
-            default:
-                debug.panic("RWeapon drop spawner crashed");
-        }
+        DropDatabase db = DropDatabase.Get();
+        String spawnedClass = db.PickWeapon();
+        spawnedItem = createDropByClass(dropper,spawnedClass);
         return spawnedItem;
     }
 
     private static play Actor SpawnRArmorDrop(Actor dropper) {
-        bool unused;
         Actor spawnedItem;
-        let dropType = rnd.weightedRand(10, 10, 5);
-        switch (dropType) {
-            case 0: 
-                [unused, spawnedItem] = dropper.A_SpawnItemEx('RwGreenArmor');
-                break;
-            case 1: 
-                [unused, spawnedItem] = dropper.A_SpawnItemEx('RwBlueArmor');
-                break;
-            case 2:
-                [unused, spawnedItem] = dropper.A_SpawnItemEx('RwEnergyArmor');
-                break;
-            default:
-                debug.panic("Drop spawner crashed");
-        }
+        DropDatabase db = DropDatabase.Get();
+        String spawnedClass = db.PickArmor();
+        spawnedItem = createDropByClass(dropper,spawnedClass);
         return spawnedItem;
     }
 
-    private static play Actor SpawnRBackpackDrop(Actor dropper) {
-        return createDropByClass(dropper, RwBackpack.GetRandomVariantClass());
-    }
+    // private static play Actor SpawnRBackpackDrop(Actor dropper) {
+    //     return createDropByClass(dropper, RwBackpack.GetRandomVariantClass());
+    // }
+        // TODO: GetRandomVariantClass is no longer necessary
+        // because subclasses of RwBackpack are added to the equipment pool
+        // and have the same weights as normal backpacks.
+        // It should probably be removed, maybe replaced with a more generic
+        // 'item skins' system that can also be used for weapons and the like.
 
-    private static play Actor SpawnRFlaskDrop(Actor dropper) {
-        let dropType = rnd.weightedRand(10, 10, 10);
-        bool unused;
+    // private static play Actor SpawnRFlaskDrop(Actor dropper) {
+    //     let dropType = rnd.weightedRand(10, 10, 10);
+    //     bool unused;
+    //     Actor spawnedItem;
+    //     switch (dropType) {
+    //         case 0: 
+    //             [unused, spawnedItem] = dropper.A_SpawnItemEx('RwSmallFlask');
+    //             break;
+    //         case 1: 
+    //             [unused, spawnedItem] = dropper.A_SpawnItemEx('RwMediumFlask');
+    //             break;
+    //         case 2:
+    //             [unused, spawnedItem] = dropper.A_SpawnItemEx('RwBigFlask');
+    //             break;
+    //         default:
+    //             debug.panic("Drop spawner crashed");
+    //     }
+    //     return spawnedItem;
+    // }
+
+    private static play Actor SpawnREquipDrop(Actor dropper) {
         Actor spawnedItem;
-        switch (dropType) {
-            case 0: 
-                [unused, spawnedItem] = dropper.A_SpawnItemEx('RwSmallFlask');
-                break;
-            case 1: 
-                [unused, spawnedItem] = dropper.A_SpawnItemEx('RwMediumFlask');
-                break;
-            case 2:
-                [unused, spawnedItem] = dropper.A_SpawnItemEx('RwBigFlask');
-                break;
-            default:
-                debug.panic("Drop spawner crashed");
-        }
+        DropDatabase db = DropDatabase.Get();
+        String spawnedClass = db.PickEquip();
+        spawnedItem = createDropByClass(dropper,spawnedClass);
         return spawnedItem;
     }
 }

--- a/zscript/misc/rnd.zs
+++ b/zscript/misc/rnd.zs
@@ -141,6 +141,29 @@ class rnd {
         return 0;
     }
 
+    static int WeightedRandArr(Array<int> weights) {
+        int sum = 0;
+        for (int i = 0; i < weights.size(); i++) {
+            int w = weights[i];
+            sum += w;
+        }
+        if (sum <= 0) { debug.panic("Bad weights sent."); }
+
+        int selected = random(0,sum-1);
+
+        for (int i = 0; i < weights.Size(); i++) {
+            if (weights[i] > 0 && selected < weights[i]) {
+                return i;
+            }
+
+            selected -= weights[i];
+        }
+
+        debug.panic("Weighted random failed to select an item.");
+        return 0;
+    }
+
+
     // Nonlinear weighted random (known as discrete geometrical distribution).
     // weightIncreaseFactor is how much times the next value is more probable than the previous one.
     // For example, if we repeatedly roll random in range 1-3 with weightIncreaseFactor 2 (each next is 2x more probable than the previous), total results will be like:

--- a/zscript/rarmor/aenergy.zs
+++ b/zscript/rarmor/aenergy.zs
@@ -4,6 +4,7 @@ class RwEnergyArmor : RandomizedArmor
 	{
 		Inventory.Pickupmessage "Energy Armor";
 		Inventory.Icon "EARMA0";
+		RandomizedArmor.Weight 5;
 	}
 	States
 	{

--- a/zscript/rarmor/randomized_armor.zs
+++ b/zscript/rarmor/randomized_armor.zs
@@ -1,4 +1,4 @@
-class RandomizedArmor : Armor {
+class RandomizedArmor : Armor abstract {
 
     mixin Affixable;
 
@@ -9,10 +9,14 @@ class RandomizedArmor : Armor {
     int lastDamageTick;
     int cumulativeRepair; 
 
+    int rweight; // Random drop weight.
+    Property Weight : rweight;
+
 	Default
 	{
 		Radius 20;
 		Height 16;
+        RandomizedArmor.Weight 10; // Same as green and blue armor.
 	}
 
     virtual void setBaseStats() {

--- a/zscript/rbackpacks/randomized_backpack.zs
+++ b/zscript/rbackpacks/randomized_backpack.zs
@@ -10,7 +10,8 @@ class RwBackpack : Inventory {
     Default {
 		Height 26;
         RwBackpack.Weight 10;
-		// Inventory.PickupMessage "$GOTBACKPACK"; }
+		Inventory.PickupMessage "$GOTBACKPACK";
+    }
 	States {
         Spawn:
             BPAK A -1;

--- a/zscript/rbackpacks/randomized_backpack.zs
+++ b/zscript/rbackpacks/randomized_backpack.zs
@@ -4,6 +4,9 @@ class RwBackpack : Inventory {
     string rwbaseName;
     RwBackpackStats stats;
 
+    int rweight; // Just like in the others, this is the weight for random drops
+    Property Weight: rweight;
+
     Default {
 		Height 26;
 		// Inventory.PickupMessage "$GOTBACKPACK";

--- a/zscript/rbackpacks/randomized_backpack.zs
+++ b/zscript/rbackpacks/randomized_backpack.zs
@@ -9,8 +9,8 @@ class RwBackpack : Inventory {
 
     Default {
 		Height 26;
-		// Inventory.PickupMessage "$GOTBACKPACK";
-	}
+        RwBackpack.Weight 10;
+		// Inventory.PickupMessage "$GOTBACKPACK"; }
 	States {
         Spawn:
             BPAK A -1;

--- a/zscript/rflasks/base_rw_flask.zs
+++ b/zscript/rflasks/base_rw_flask.zs
@@ -1,4 +1,4 @@
-class RwFlask : Inventory {
+class RwFlask : Inventory abstract {
     mixin Affixable;
     RwFlaskStats stats;
     string rwbaseName;
@@ -6,8 +6,12 @@ class RwFlask : Inventory {
     // Current vars
     int currentCharges, cooldownTicksRemaining;
 
+    int rweight;
+    Property Weight: rweight;
+
     Default {
         Height 26;
+        RwFlask.Weight 10;
     }
     States {
         Spawn:

--- a/zscript/rweapons/randomized_weapon.zs
+++ b/zscript/rweapons/randomized_weapon.zs
@@ -1,13 +1,17 @@
-class RandomizedWeapon : DoomWeapon {
+class RandomizedWeapon : DoomWeapon abstract {
 
     mixin Affixable;
 
     string rwbaseName;
     RWStatsClass stats;
 
+    int rweight; // Weight for randomization.
+    Property Weight : rweight; //
+
     Default {
         Weapon.AmmoUse 1; // We use custom ammo usage routine anyway
         Weapon.AmmoGive 0; // Ammo is dropped separately so that the player doesn't have to "press use to pick it up"
+        RandomizedWeapon.Weight 20; // A sane default--about as common as the Chaingun and SMG.
     }
 
     virtual void setBaseStats() {

--- a/zscript/rweapons/w1chainsaw.zs
+++ b/zscript/rweapons/w1chainsaw.zs
@@ -17,6 +17,7 @@ class RwChainsaw : RandomizedWeapon
 		Tag "$TAG_CHAINSAW";
 		+WEAPON.MELEEWEAPON		
 		+WEAPON.NOAUTOSWITCHTO
+		RandomizedWeapon.Weight 5;
 	}
 	States
 	{

--- a/zscript/rweapons/w2pistol.zs
+++ b/zscript/rweapons/w2pistol.zs
@@ -10,6 +10,7 @@ class rwPistol : RandomizedWeapon
 		Obituary "$OB_MPPISTOL";
 		Inventory.PickupMessage "$GOTPISTOL";
 		Tag "$TAG_PISTOL";
+		RandomizedWeapon.Weight 25;
 	}
 	States
 	{

--- a/zscript/rweapons/w3shotgun.zs
+++ b/zscript/rweapons/w3shotgun.zs
@@ -10,6 +10,7 @@ class rwShotgun : RandomizedWeapon
 		Inventory.PickupMessage "$GOTSHOTGUN";
 		Obituary "$OB_MPSHOTGUN";
 		Tag "$TAG_SHOTGUN";
+		RandomizedWeapon.Weight 25;
 	}
 	States
 	{

--- a/zscript/rweapons/w3ssg.zs
+++ b/zscript/rweapons/w3ssg.zs
@@ -10,6 +10,7 @@ class RwSuperShotgun : RandomizedWeapon
 		Inventory.PickupMessage "$GOTSHOTGUN2";
 		Obituary "$OB_MPSSHOTGUN";
 		Tag "$TAG_SUPERSHOTGUN";
+		RandomizedWeapon.Weight 15;
 	}
 	States
 	{

--- a/zscript/rweapons/w4chaingun.zs
+++ b/zscript/rweapons/w4chaingun.zs
@@ -36,6 +36,7 @@ class RwChaingun : RandomizedWeapon
 		Inventory.PickupMessage "$GOTCHAINGUN";
 		Obituary "$OB_MPCHAINGUN";
 		Tag "$TAG_CHAINGUN";
+		RandomizedWeapon.Weight 20;
 	}
 	States
 	{

--- a/zscript/rweapons/w4smg.zs
+++ b/zscript/rweapons/w4smg.zs
@@ -10,6 +10,7 @@ class RwSmg : RandomizedWeapon
 		Inventory.PickupMessage "$GOTSMG";
 		Obituary "$OB_MPSMG";
 		Tag "$TAG_SMG";
+		RandomizedWeapon.Weight 20;
 	}
 	States
 	{

--- a/zscript/rweapons/w5rocketlauncher.zs
+++ b/zscript/rweapons/w5rocketlauncher.zs
@@ -10,6 +10,7 @@ class RwRocketLauncher : RandomizedWeapon
 		+WEAPON.NOAUTOFIRE
 		Inventory.PickupMessage "$GOTLAUNCHER";
 		Tag "$TAG_ROCKETLAUNCHER";
+		RandomizedWeapon.Weight 10;
 	}
 	States
 	{

--- a/zscript/rweapons/w6plasmarifle.zs
+++ b/zscript/rweapons/w6plasmarifle.zs
@@ -9,6 +9,7 @@ class RwPlasmaRifle : RandomizedWeapon
 		Weapon.AmmoType "Cell";
 		Inventory.PickupMessage "$GOTPLASMA";
 		Tag "$TAG_PLASMARIFLE";
+		RandomizedWeapon.Weight 10;
 	}
 	States
 	{

--- a/zscript/rweapons/w7bfg.zs
+++ b/zscript/rweapons/w7bfg.zs
@@ -9,6 +9,7 @@ class RwBFG : RandomizedWeapon
 		+WEAPON.NOAUTOFIRE;
 		Inventory.PickupMessage "$GOTBFG9000";
 		Tag "$TAG_BFG9000";
+		RandomizedWeapon.Weight 1;
 	}
 	States
 	{

--- a/zscript/rweapons/w7bfg2704.zs
+++ b/zscript/rweapons/w7bfg2704.zs
@@ -9,6 +9,7 @@ class RwBFG2704 : RandomizedWeapon
 		+WEAPON.NOAUTOFIRE;
 		Inventory.PickupMessage "$GOTBFG9000";
 		Tag "$TAG_BFG9000";
+		RandomizedWeapon.Weight 1;
 	}
 	States
 	{


### PR DESCRIPTION
Finally got this wrapped up, I think.

- DropDatabase currently looks for all non-abstract items of the following classes: RandomizedWeapon, RandomizedArmor, RwBackpack, RwFlask. 
- Ammo items and "One Time" items have been inserted into their lists manually inside DropDatabase. This is kinda ugly, but unless you feel like replacing all of the ammo pickups and all of the health/powerup items, it's what works. (I'm thinking about changing health pickups anyway, to make them work better with health upgrades.)
- I also changed RandomizedWeapon, RandomizedArmor, and RwFlask to Abstract classes. This doesn't change their behavior at all, but it does mean that they'll be excluded from the drop lists, since they're not supposed to be dropped.
- A side effect of this is that backpack variants are now added to the drop pool directly, rather than being created by the Backpack.GetRandomVariantClass() function. In addition, backpacks and flasks have been merged into a single EquipItems list. This doesn't change anything yet, since the weights of backpacks and flasks are all the same, but this could have effects in the future...but also, I didn't really want to have a list that *just* has backpacks in it. Maybe if new backpacks get added...

TODO: It would be nice to have some way of adding new list types without having to modify DropDatabase itself. Will mull this over and work on it later. Currently considering some sort of DropCategory class which is enumerated at startup by DropDatabase and contains both a weight for the Category in question *and* a list of items, which would then replace the WeaponItems, AmmoItems, etc. lists that are defined in DropDatabase. This would be super flexible, and would make adding entirely new types of equipment easier--IDK if it'd make it possible to put new equipment types into an addon mod, but it would be a step toward that. That said, I wanted to get this done so I can add the Blaster already :p